### PR TITLE
[CORESTRAIN-2777] Initial fork setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,24 @@
 # Compose LazyList/Grid reorder
 [![Latest release](https://img.shields.io/github/v/release/aclassen/ComposeReorderable?color=brightgreen&label=latest%20release)](https://github.com/aclassen/ComposeReorderable/releases/latest)
 
-A Jetpack Compose (Android + Desktop) modifier enabling reordering by drag and drop in a LazyList and LazyGrid.
+A Jetpack Compose modifier enabling reordering by drag and drop in a LazyList and LazyGrid.
 
 ![Sample](readme/sample.gif)
 
-## Download
+## WHOOP Fork
 
-```
-dependencies {
-    implementation("org.burnoutcrew.composereorderable:reorderable:<latest_version>")
-}
-```
+This library is forked from Andre Claßen's open source library
+[ComposeReorderable](https://github.com/aclassen/ComposeReorderable).
+
+We are using a custom WHOOP fork so that we can customize the implementation to suit our needs,
+as well as to mitigate risk in case the 3rd party library ever stops being maintained.
+
+The `main` branch is just a copy of the upstream library's `main` branch, while the `whoop` branch
+contains any whoop-specific code. When making whoop-specific changes, you should branch off from
+`whoop` into a new feature branch, and open a PR back onto the `whoop` branch.
+
+### Updating the Fork
+Ask a maintainer for instructions on how to update the fork. We keep these instructions internal.
 
 ## How to use
 

--- a/reorderable/build.gradle.kts
+++ b/reorderable/build.gradle.kts
@@ -7,8 +7,8 @@ plugins {
     id("signing")
 }
 
-group = "org.burnoutcrew.composereorderable"
-version = "0.9.7"
+group = "com.whoop.composereorderable"
+version = "0.109.7" // we add 100 to the minor version to avoid conflicts with upstream version
 
 kotlin {
     jvm()
@@ -35,13 +35,13 @@ publishing {
     publications {
         repositories {
             maven {
-                name="oss"
-                val releasesRepoUrl = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
-                val snapshotsRepoUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-                url = if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
+                name="internal"
+                val releasesRepoUrl = extra.properties.getOrDefault("internalUrl", "") as String
+                val snapshotsRepoUrl = extra.properties.getOrDefault("internalSnapshotUrl", "") as String
+                url = if (version.toString().endsWith("SNAPSHOT")) uri(snapshotsRepoUrl) else uri(releasesRepoUrl)
                 credentials {
-                    username = extra.properties.getOrDefault("ossrh.Username", "") as String
-                    password = extra.properties.getOrDefault("ossrh.Password", "") as String
+                    username = extra.properties.getOrDefault("internalUsername", "") as String
+                    password = extra.properties.getOrDefault("internalPassword", "") as String
                 }
             }
         }
@@ -58,14 +58,14 @@ publishing {
                         url.set("https://opensource.org/licenses/Apache-2.0")
                     }
                 }
-                url.set("https://github.com/aclassen/ComposeReorderable")
+                url.set("https://github.com/WhoopInc/ComposeReorderable")
                 issueManagement {
                     system.set("Github")
-                    url.set("https://github.com/aclassen/ComposeReorderable/issues")
+                    url.set("https://github.com/WhoopInc/ComposeReorderable/issues")
                 }
                 scm {
-                    connection.set("https://github.com/aclassen/ComposeReorderable.git")
-                    url.set("https://github.com/aclassen/ComposeReorderable")
+                    connection.set("https://github.com/WhoopInc/ComposeReorderable.git")
+                    url.set("https://github.com/WhoopInc/ComposeReorderable")
                 }
                 developers {
                     developer {
@@ -79,5 +79,6 @@ publishing {
 }
 
 signing {
+    isRequired = false
     sign(publishing.publications)
 }


### PR DESCRIPTION
Updated the build script so that we can create releases to our internal repository under the `com.whoop` group.

Also updated the README to explain the reason for the fork.

I verified that we can publish to our internal repository using this Gradle setup, and pulled in the artifact to my local android project to verify drag and drop works with this fork as a dependency.